### PR TITLE
Nebula command changed to `bundle` not `run`

### DIFF
--- a/docs/deployment/nebula/running-nebula.md
+++ b/docs/deployment/nebula/running-nebula.md
@@ -9,7 +9,7 @@ Once we wrote our `lyra.yml` and `get-data.js` file, we can finally run Nebula.
 Running it is as simple as:
 
 ```bash
-$ nebula run
+$ nebula bundle
 ```
 
 It will produce a `dist/index.js` file, which we can deploy to Cloudflare


### PR DESCRIPTION
The current documentation says to run the command `nebula run` which doesn't exist in the CLI, but `nebula run` does work and appears to be the correct command