### PR TITLE
docs: improve default value of enableStopWords

### DIFF
--- a/docs/06-text-analysis/02-stop-words.md
+++ b/docs/06-text-analysis/02-stop-words.md
@@ -23,7 +23,7 @@ As for now, Lyra supports 12 languages when it comes to stop-words removal:
 
 ## Disabling stop-words removal
 
-You can disable stop-words removal by setting `enableStopWords: false` when creating a new Lyra instance:
+By default, `enableStopWords` is `true` but you can disable stop-words removal by setting `enableStopWords: false` when creating a new Lyra instance:
 
 ```javascript
 import { create } from "@lyrasearch/lyra";


### PR DESCRIPTION
Hi, I'd like to suggest this documentation improvement to make more clear de default value of `enableStopWords` option.